### PR TITLE
add feed for blog.ramon-gordillo

### DIFF
--- a/src/data/aggregator-feeds.yaml
+++ b/src/data/aggregator-feeds.yaml
@@ -24,6 +24,7 @@ feeds:
   - url: https://quarkus.io/feed.xml
   - url: https://resteasy.github.io/feed.xml
   - url: https://vertx.io/feed.xml
+  - url: https://blog.ramon-gordillo.dev/index.xml
 
 # end of list
 


### PR DESCRIPTION
Add https://blog.ramon-gordillo.dev/ as a feed source.