### PR TITLE
Improve error handling + disable vertx

### DIFF
--- a/aggregate.js
+++ b/aggregate.js
@@ -26,7 +26,7 @@ const processFeed = (feedConfig) => {
         }]);
         fetch(feedConfig.url).then(res => {
             if (res.status !== 200) {
-                reject('Response return not 200, code=' + res.status + ' feed_url=' + url + ' response_text=' + res.statusText);
+                reject('Response return not 200, code=' + res.status + ' response_text=' + res.statusText);
             } else {
                 // The response `body` -- res.body -- is a stream
                 res.body.pipe(feedparser);
@@ -80,7 +80,7 @@ feedsJson.forEach((feed, index) => {
             console.log("ALL FEEDS FETCHED feeds_count=%s blog_posts_count=%s execution_time=%sms", feedsProcessed, allPosts.length, duration);
             allPostsFetched(allPosts);
         }
-    }).catch(err => logErrorAndExit("Cannot parse feed. feed_url=" + item, err));
+    }).catch(err => logErrorAndExit("Cannot parse feed. feed_url=" + feed.url, err));
 });
 
 // All feeds and their blog posts fetched. Pick last 20 and store them

--- a/src/data/aggregator-feeds.yaml
+++ b/src/data/aggregator-feeds.yaml
@@ -23,7 +23,8 @@ feeds:
   - url: https://www.wildfly.org/feed.xml
   - url: https://quarkus.io/feed.xml
   - url: https://resteasy.github.io/feed.xml
-  - url: https://vertx.io/feed.xml
+  # vertx website has changed and there is no link to RSS feed
+  #- url: https://vertx.io/feed.xml
   - url: https://blog.ramon-gordillo.dev/index.xml
 
 # end of list


### PR DESCRIPTION
vertx returns 404 which stops aggregator.
this is expected behaviour because temporary 404 can happen.
However there is no info what is correct URL so I disabled this feed.

I fixed also aggregator.js to correctly fail if 404 happens.