### PR TITLE
Spell OptaPlanner correctly

### DIFF
--- a/src/content/pages/trademarks.adoc
+++ b/src/content/pages/trademarks.adoc
@@ -60,7 +60,7 @@ ModeShape +
 Narayana +
 Nodeshift +
 Nodyn +
-Optaplanner +
+OptaPlanner +
 Overard +
 Overlord +
 Papaki +


### PR DESCRIPTION
See https://www.optaplanner.org/community/branding.html for more details.