### PR TITLE
Restore RESTEasy feed with correct URL

### DIFF
--- a/src/data/aggregator-feeds.yaml
+++ b/src/data/aggregator-feeds.yaml
@@ -21,7 +21,7 @@ feeds:
   - url: https://blog.kie.org/feed/atom
   - url: https://www.wildfly.org/feed.xml
   - url: https://quarkus.io/feed.xml
-  # - url: https://resteasy.github.io/feed.xml
+  - url: https://resteasy.dev/feed.xml
   # vertx website has changed and there is no link to RSS feed
   - url: https://vertx.io/feed/atom.xml
   - url: https://jbossts.blogspot.com/feeds/posts/default


### PR DESCRIPTION
This should be the correct fix for the problem worked around in https://github.com/jbossorg/jbossorg.github.io/pull/127 
/cc @rpelisse @jamezp 